### PR TITLE
Fix deprecated vacuum states in vacuum entity

### DIFF
--- a/custom_components/zcsmower/vacuum.py
+++ b/custom_components/zcsmower/vacuum.py
@@ -113,7 +113,7 @@ class ZcsMowerRobotVacuumEntity(ZcsMowerRobotEntity, StateVacuumEntity):
             return VacuumActivity.STATE_RETURNING
         if self._get_attribute(ATTR_STATE) == "work_standby":
             return VacuumActivity.STATE_IDLE
-        return STATE_ERROR
+        return VacuumActivity.STATE_ERROR
 
     @property
     def error(self) -> str | None:

--- a/custom_components/zcsmower/vacuum.py
+++ b/custom_components/zcsmower/vacuum.py
@@ -8,12 +8,12 @@ from homeassistant.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.vacuum import (
     ATTR_STATUS,
-    STATE_CLEANING,
-    STATE_DOCKED,
-    STATE_PAUSED,
-    STATE_IDLE,
-    STATE_RETURNING,
-    STATE_ERROR,
+    VacuumActivity.STATE_CLEANING,
+    VacuumActivity.STATE_DOCKED,
+    VacuumActivity.STATE_PAUSED,
+    VacuumActivity.STATE_IDLE,
+    VacuumActivity.STATE_RETURNING,
+    VacuumActivity.STATE_ERROR,
     StateVacuumEntity,
     StateVacuumEntityDescription,
     VacuumEntityFeature,
@@ -104,15 +104,15 @@ class ZcsMowerRobotVacuumEntity(ZcsMowerRobotEntity, StateVacuumEntity):
     def state(self) -> str:
         """Return the state of the lawn mower."""
         if self._get_attribute(ATTR_STATE) in ("work", "gotoarea", "bordercut", "mapping_started"):
-            return STATE_CLEANING
+            return VacuumActivity.STATE_CLEANING
         if self._get_attribute(ATTR_STATE) == "charge":
-            return STATE_DOCKED
+            return VacuumActivity.STATE_DOCKED
         if self._get_attribute(ATTR_STATE) == "pause":
-            return STATE_PAUSED
+            return VacuumActivity.STATE_PAUSED
         if self._get_attribute(ATTR_STATE) in ("gotostation", "mapping_ended"):
-            return STATE_RETURNING
+            return VacuumActivity.STATE_RETURNING
         if self._get_attribute(ATTR_STATE) == "work_standby":
-            return STATE_IDLE
+            return VacuumActivity.STATE_IDLE
         return STATE_ERROR
 
     @property


### PR DESCRIPTION
Fixing error:

2025-01-14 19:52:56.113 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_CLEANING was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.CLEANING instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.128 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_DOCKED was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.DOCKED instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.139 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_PAUSED was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.PAUSED instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.155 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_IDLE was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.IDLE instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.168 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_RETURNING was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.RETURNING instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.183 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_ERROR was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.ERROR instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.193 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_CLEANING was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.CLEANING instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.205 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_DOCKED was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.DOCKED instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.215 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_PAUSED was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.PAUSED instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.225 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_IDLE was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.IDLE instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.238 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_RETURNING was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.RETURNING instead, please report it to the author of the 'zcsmower' custom integration 2025-01-14 19:52:56.248 WARNING (ImportExecutor_0) [homeassistant.components.vacuum] STATE_ERROR was used from zcsmower, this is a deprecated constant which will be removed in HA Core 2026.1. Use VacuumActivity.ERROR instead, please report it to the author of the 'zcsmower' custom integration